### PR TITLE
fix: remove reusePort option to resolve server listen ENOTSUP error

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
-import express, { type Request, Response, NextFunction } from "express";
+import express, { NextFunction, type Request, Response } from "express";
 import { registerRoutes } from "./routes";
-import { setupVite, serveStatic, log } from "./vite";
+import { log, serveStatic, setupVite } from "./vite";
 
 const app = express();
 app.use(express.json());
@@ -75,7 +75,6 @@ app.use((req, res, next) => {
   server.listen({
     port,
     host: "0.0.0.0",
-    reusePort: true,
   }, () => {
     log(`serving on port ${port}`);
   });


### PR DESCRIPTION
This pull request removes the reusePort option from the server.listen call in server/index.ts to fix the ENOTSUP error when starting the server on port 5000.